### PR TITLE
Add package.json and stringify communication to server

### DIFF
--- a/client/editor.js
+++ b/client/editor.js
@@ -52,12 +52,12 @@ function closeView() {
 }
 
 function handleDone(newData) {
-    alt.emitServer('character:Done', newData);
+    alt.emitServer('character:Done', JSON.stringify(newData));
     closeView();
 }
 
 function handleCancel() {
-    alt.emitServer('character:Done', oldData);
+    alt.emitServer('character:Done', JSON.stringify(oldData));
     closeView();
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}


### PR DESCRIPTION
Added a package.json containing only a single line to fix the issue described in the readme.
Fix transmission of characterData to C# server backend by including an explicit json conversion for the data. It wasn't explicitly stringified in the JS code, and that broke the receiving side of C# servers. 